### PR TITLE
added more sub-rules that "capture" the terminal values within a constant expression

### DIFF
--- a/src/language/card-dsl.langium
+++ b/src/language/card-dsl.langium
@@ -158,16 +158,31 @@ MultExpr infers Expr:
     PrimExpr ({infer BinExpr.left=current} op=('*'|'/') right=PrimExpr)*;
 
 PrimExpr infers Expr:
-    INT ({infer IntConstant.value=current}) | 
-    ElementCategory ({infer ElementCategoryConstant.value=current}) |
-    CardType ({infer CardTypeConstant.value=current}) |
-    MonsterTrait ({infer MonsterTraitConstant.value=current}) |
-    Variable ({infer Variable.value=current}) | 
+    IntConstantExpr ({infer IntConstant.value=current}) | 
+    ElementCategoryConstantExpr ({infer ElementCategoryConstant.value=current}) |
+    CardTypeConstantExpr ({infer CardTypeConstant.value=current}) |
+    MonsterTraitConstantExpr ({infer MonsterTraitConstant.value=current}) |
+    VariableExpr ({infer VariableExpression.value=current}) | 
     "this" ({infer ThisConstant.value=current}) |
     '(' Expr ')';
 
 // Conditions for where clauses
 Condition: Expr;
+
+IntConstantExpr:
+    rawValue=INT;
+
+ElementCategoryConstantExpr:
+    rawValue=ElementCategory;
+
+CardTypeConstantExpr:
+    rawValue=CardType;
+
+MonsterTraitConstantExpr:
+    rawValue=MonsterTrait;
+
+VariableExpr:
+    rawValue=Variable;
 
 SelectSource returns string:
     // Battlefield

--- a/src/language/utils/typecheck-utils.ts
+++ b/src/language/utils/typecheck-utils.ts
@@ -1,5 +1,15 @@
 import { ValidationAcceptor } from "langium";
-import { Expr, Variable } from "../generated/ast.js";
+import { 
+    Expr, 
+    isBinExpr, 
+    isCardTypeConstant, 
+    isElementCategoryConstant, 
+    isIntConstant, 
+    isMonsterTraitConstant, 
+    isThisConstant, 
+    isVariableExpression, 
+    Variable
+} from "../generated/ast.js";
 
 
 type ExpressionType = 'trait' | 'card_type' | 'element_category' | 'number' | "card_obj" | "boolean" | undefined;
@@ -31,7 +41,7 @@ export function checkExpression(expression: Expr, accept: ValidationAcceptor): E
         return undefined;
     }
 
-    if(expression.$type === 'BinExpr') {
+    if(isBinExpr(expression)) {
         const lhsType = checkExpression(expression.left, accept);
         const rhsType = checkExpression(expression.right, accept);
 
@@ -64,27 +74,27 @@ export function checkExpression(expression: Expr, accept: ValidationAcceptor): E
         return "boolean"
     }
 
-    if(expression.$type === 'IntConstant') {
+    if(isIntConstant(expression)) {
         return 'number'
     }
 
-    if(expression.$type === 'CardTypeConstant') {
+    if(isCardTypeConstant(expression)) {
         return 'card_type'
     }
 
-    if(expression.$type === 'ElementCategoryConstant') {
+    if(isElementCategoryConstant(expression)) {
         return 'element_category'
     }
 
-    if(expression.$type === 'MonsterTraitConstant') {
+    if(isMonsterTraitConstant(expression)) {
         return 'trait'
     }
 
-    if(expression.$type === 'Variable') {
-        return getVariableType(expression.value as Variable)
+    if(isVariableExpression(expression)) {
+        return getVariableType(expression.value.rawValue)
     }
 
-    if(expression.$type === 'ThisConstant') {
+    if(isThisConstant(expression)) {
         return 'card_obj'
     }
 

--- a/test/linking/linking.test.ts
+++ b/test/linking/linking.test.ts
@@ -25,8 +25,21 @@ describe('Linking tests', () => {
 
     test('linking of greetings', async () => {
         document = await parse(`
-            person Langium
-            Hello Langium!
+name: "Ifrit" 
+id: 1
+type: monster
+category: fire
+artwork: "https://manacards.s3.fr-par.scw.cloud/cards/ifrit.webp"
+traits: spellcaster
+attack: 3000
+hp: 1000
+stars: 10
+description: "Lord of fire and destruction"
+abilities:
+    [active] "Annihilation":
+        description: "Destroy all monsters on the field except for Ifrit"
+        auto select $allCards from the battlefield where (($allCards.category = fire) and ($allCards.attack < $allCards.hp))
+        [effect] destroy $allCards
         `);
 
         expect(
@@ -35,9 +48,9 @@ describe('Linking tests', () => {
             // and then evaluate the cross references we're interested in by checking
             //  the referenced AST element as well as for a potential error message;
             checkDocumentValid(document)
-                || document.parseResult.value.greetings.map(g => g.person.ref?.name || g.person.error?.message).join('\n')
+                || document.parseResult.value.cards.map(g => g.name).join('\n')
         ).toBe(s`
-            Langium
+            Ifrit
         `);
     });
 });

--- a/test/parsing/parsing.test.ts
+++ b/test/parsing/parsing.test.ts
@@ -3,7 +3,7 @@ import { EmptyFileSystem, type LangiumDocument } from "langium";
 import { expandToString as s } from "langium/generate";
 import { parseHelper } from "langium/test";
 import { createCardDslServices } from "../../src/language/card-dsl-module.js";
-import { BinExpr, ElementCategoryConstant, Model, MonsterCard, SelectStep, isEffectStep, isElementCategoryConstant, isSelectStep } from "../../src/language/generated/ast.js";
+import { BinExpr, ElementCategoryConstant, ElementCategoryConstantExpr, Model, MonsterCard, SelectStep, isEffectStep, isElementCategoryConstant, isElementCategoryConstantExpr, isSelectStep } from "../../src/language/generated/ast.js";
 
 let services: ReturnType<typeof createCardDslServices>;
 let parse:    ReturnType<typeof parseHelper<Model>>;
@@ -36,7 +36,6 @@ abilities:
         description: "Destroy all monsters on the field except for Ifrit"
         auto select $allCards from the battlefield where($allCards.category = fire)
         [effect] destroy $allCards
-
         `);
 
         // Check overall status
@@ -67,8 +66,10 @@ abilities:
         expect(monsterCard.abilities[0].steps.length).toBe(2);
 
 
-        expect(isSelectStep(monsterCard.abilities[0].steps[0])).toBe(true);
-        expect(isEffectStep(monsterCard.abilities[0].steps[1])).toBe(true);
+        expect(isSelectStep(monsterCard.abilities[0].steps[0])?"step 0 is a select step": "step 0 is not a select step")
+            .toBe("step 0 is a select step");
+        expect(isEffectStep(monsterCard.abilities[0].steps[1])?"step 1 is an effect step": "step 1 is not an effect step")
+            .toBe("step 1 is an effect step");
 
         const selectStep = monsterCard.abilities[0].steps[0] as SelectStep;
         //expect(isBinExpr(selectStep.condition)).toBe(true);
@@ -76,9 +77,10 @@ abilities:
         const binExpr = selectStep.condition as BinExpr;
 
         const rhs = binExpr.right;
-        expect(isElementCategoryConstant(rhs)).toBe(true);
+        expect(isElementCategoryConstant(rhs)?"rhs is an element category constant expression": "rhs is not an element category constant expression")
+            .toBe("rhs is an element category constant expression");
 
         const categoryConstant = rhs as ElementCategoryConstant;
-        expect(categoryConstant.value).toBe('fire');
+        expect(categoryConstant.value.rawValue).toBe('fire');
     });
 });

--- a/test/parsing/parsing.test.ts
+++ b/test/parsing/parsing.test.ts
@@ -3,7 +3,7 @@ import { EmptyFileSystem, type LangiumDocument } from "langium";
 import { expandToString as s } from "langium/generate";
 import { parseHelper } from "langium/test";
 import { createCardDslServices } from "../../src/language/card-dsl-module.js";
-import { BinExpr, ElementCategoryConstant, ElementCategoryConstantExpr, Model, MonsterCard, SelectStep, isEffectStep, isElementCategoryConstant, isElementCategoryConstantExpr, isSelectStep } from "../../src/language/generated/ast.js";
+import { BinExpr, ElementCategoryConstant, Model, MonsterCard, SelectStep, isEffectStep, isElementCategoryConstant, isSelectStep } from "../../src/language/generated/ast.js";
 
 let services: ReturnType<typeof createCardDslServices>;
 let parse:    ReturnType<typeof parseHelper<Model>>;

--- a/test/validating/validating.test.ts
+++ b/test/validating/validating.test.ts
@@ -20,7 +20,77 @@ beforeAll(async () => {
 });
 
 describe('Validating', () => {
-  
+    test("should detect that the monster is too powerful", async () => {
+        document = await parse(`
+name: "Ifrit" 
+id: 1
+type: monster
+category: fire
+artwork: "https://manacards.s3.fr-par.scw.cloud/cards/ifrit.webp"
+traits: spellcaster
+attack: 10001
+hp: 1000
+stars: 10
+description: "Lord of fire and destruction"
+abilities:
+    [active] "Annihilation":
+        description: "Destroy all monsters on the field except for Ifrit"
+        auto select $allCards from the battlefield where($allCards.category = fire)
+        [effect] destroy $allCards
+        `);
+        
+        const diagnostics = document.diagnostics ?? [];
+        expect(checkDocumentValid(document)).toBeUndefined();
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0].message).toContain("Monster too powerful. Heard about game balance?");
+    });
+
+    test("should detect invalid health = 0", async () => {
+        document = await parse(`
+name: "Ifrit" 
+id: 1
+type: monster
+category: fire
+artwork: "https://manacards.s3.fr-par.scw.cloud/cards/ifrit.webp"
+traits: spellcaster
+attack: 3000
+hp: 0
+stars: 10
+description: "Lord of fire and destruction"
+abilities:
+    [active] "Annihilation":
+        description: "Destroy all monsters on the field except for Ifrit"
+        auto select $allCards from the battlefield where($allCards.category = fire)
+        [effect] destroy $allCards
+        `);
+        
+        const diagnostics = document.diagnostics ?? [];
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0].message).toContain("Monster health must be greater than 0.");
+    });
+
+    test("should not complain about a valid card", async () => {
+        document = await parse(`
+name: "Ifrit" 
+id: 1
+type: monster
+category: fire
+artwork: "https://manacards.s3.fr-par.scw.cloud/cards/ifrit.webp"
+traits: spellcaster
+attack: 3000
+hp: 3000
+stars: 10
+description: "Lord of fire and destruction"
+abilities:
+    [active] "Annihilation":
+        description: "Destroy all monsters on the field except for Ifrit"
+        auto select $allCards from the battlefield where($allCards.category = fire)
+        [effect] destroy $allCards
+        `);
+        
+        const diagnostics = document.diagnostics ?? [];
+        expect(diagnostics).toHaveLength(0);
+    });
 });
 
 function checkDocumentValid(document: LangiumDocument): string | undefined {
@@ -31,8 +101,4 @@ function checkDocumentValid(document: LangiumDocument): string | undefined {
         || document.parseResult.value === undefined && `ParseResult is 'undefined'.`
         || !isModel(document.parseResult.value) && `Root AST object is a ${document.parseResult.value.$type}, expected a '${Model}'.`
         || undefined;
-}
-
-function diagnosticToString(d: Diagnostic) {
-    return `[${d.range.start.line}:${d.range.start.character}..${d.range.end.line}:${d.range.end.character}]: ${d.message}`;
 }

--- a/test/validating/validating.test.ts
+++ b/test/validating/validating.test.ts
@@ -2,7 +2,6 @@ import { beforeAll, describe, expect, test } from "vitest";
 import { EmptyFileSystem, type LangiumDocument } from "langium";
 import { expandToString as s } from "langium/generate";
 import { parseHelper } from "langium/test";
-import type { Diagnostic } from "vscode-languageserver-types";
 import { createCardDslServices } from "../../src/language/card-dsl-module.js";
 import { Model, isModel } from "../../src/language/generated/ast.js";
 

--- a/test/validating/validating.test.ts
+++ b/test/validating/validating.test.ts
@@ -21,34 +21,6 @@ beforeAll(async () => {
 
 describe('Validating', () => {
   
-    test('check no errors', async () => {
-        document = await parse(`
-            person Langium
-        `);
-
-        expect(
-            // here we first check for validity of the parsed document object by means of the reusable function
-            //  'checkDocumentValid()' to sort out (critical) typos first,
-            // and then evaluate the diagnostics by converting them into human readable strings;
-            // note that 'toHaveLength()' works for arrays and strings alike ;-)
-            checkDocumentValid(document) || document?.diagnostics?.map(diagnosticToString)?.join('\n')
-        ).toHaveLength(0);
-    });
-
-    test('check capital letter validation', async () => {
-        document = await parse(`
-            person langium
-        `);
-
-        expect(
-            checkDocumentValid(document) || document?.diagnostics?.map(diagnosticToString)?.join('\n')
-        ).toEqual(
-            // 'expect.stringContaining()' makes our test robust against future additions of further validation rules
-            expect.stringContaining(s`
-                [1:19..1:26]: Person name should start with a capital.
-            `)
-        );
-    });
 });
 
 function checkDocumentValid(document: LangiumDocument): string | undefined {


### PR DESCRIPTION
This PR attempts to improve the structure of the AST for ease of testing/serialization

The issue was first caught when looking at the JSON serialized ast of a card. 
Here is an example:
```
auto select $allCards from the battlefield where (($allCards.category = fire) and ($allCards.attack < $allCards.hp))
```

Specifically, we are interested in the following condition:
```
$allCards.category = fire
```

The serialized JSON looks as follows:
```json
{
    "op": "=",
    "left": {
        "$type": "Variable",
        "value": {
            "ref": {
                "$ref": "#/cards@0/abilities@0/steps@0/variable"
            },
            "prop": "category",
            "$type": "Variable"
        }
    },
    "$type": "BinExpr",
    "right": {
        "$type": "ElementCategoryConstant",
        "value": {
            "$type": "Expr"
        }
    }
}
```

The `fire` constant is not present, which implies it probably wasn't present in the AST as well.

Upon further investigation, it seemed that the issues lies within `PrimExpr`:
```langium
PrimExpr infers Expr:
    INT ({infer IntConstant.value=current}) | 
    ElementCategory ({infer ElementCategoryConstant.value=current}) |
    CardType ({infer CardTypeConstant.value=current}) |
    MonsterTrait ({infer MonsterTraitConstant.value=current}) |
    Variable ({infer Variable.value=current}) | 
    "this" ({infer ThisConstant.value=current}) |
    '(' Expr ')';
```

where for example, `ElementCategory` is a rule that returns a `string`:
```langium
ElementCategory returns string:
    'dark' | 'light' | 'fire' | 'water' | 'earth' | 'wind';
```


However, in AST, accessing the AST `ElementCategory.type`, results in an object. 

The test `parsing.test.ts` has been implemented in master and has failed (after identifying this bug).

